### PR TITLE
Cargo: Add default-run for the game binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "harmonicon"
 version = "0.1.0"
 edition = "2024"
 license = "MIT"
+default-run = "harmonicon"
 
 [dependencies]
 # `wav` lets bevy_audio decode the in-memory WAV the song editor synthesises for


### PR DESCRIPTION
The crate has five binaries, so a bare cargo run does not know which one to pick and fails.