### PR TITLE
Cargo: Add a lints table for the Bevy allows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,8 +59,12 @@ jobs:
           components: clippy
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
+      # --all-targets: the plain form skips the binaries in src/bin, the
+      # tests and build.rs, which is most of what a review actually breaks.
       - name: Run clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
+      - name: Run clippy with the dev feature
+        run: cargo clippy --all-targets --features dev -- -D warnings
 
   # Run cargo fmt --all -- --check
   format:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,16 @@ dev = [
 # needs (spans below `info` are dropped before any backend sees them).
 trace_tracy = ["bevy/trace_tracy"]
 
+# Bevy systems routinely take one parameter per resource/component/message
+# type they touch — that's the ECS, not a design smell — and `Query` filter
+# tuples like `(With<A>, Without<B>, Without<C>)` are inherently "complex" by
+# that lint's simple heuristic despite being completely idiomatic Bevy.
+# Here rather than as a `lib.rs` inner attribute so the binaries and the
+# integration tests are held to the same set as the library.
+[lints.clippy]
+too_many_arguments = "allow"
+type_complexity = "allow"
+
 [[bin]]
 name = "hole-editor"
 path = "src/bin/hole_editor.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,13 +6,6 @@
 //! (`src/main.rs`) and the helper tools in `src/bin/` (e.g. `hole-editor`),
 //! which are separate crates and can only reach this code through the library.
 
-// Bevy systems routinely take one parameter per resource/component/message
-// type they touch — that's the ECS, not a design smell — and `Query` filter
-// tuples like `(With<A>, Without<B>, Without<C>)` are inherently "complex" by
-// this lint's simple heuristic despite being completely idiomatic Bevy.
-// Allowed crate-wide rather than annotating every system individually.
-#![allow(clippy::too_many_arguments, clippy::type_complexity)]
-
 pub mod app;
 pub mod assets_management;
 pub mod audio_system;


### PR DESCRIPTION
An inner attribute in lib.rs only covers the library, so the four
binaries and the integration tests were linted by a different set.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>