### PR TITLE
gameplay: overlays: Order clock readers after GameplayLogic

### DIFF
--- a/src/gameplay/countdown_overlay.rs
+++ b/src/gameplay/countdown_overlay.rs
@@ -13,7 +13,9 @@ use crate::{
     song::SongManifest,
 };
 
-use super::{GameplayClock, GameplayRoot, MidiTrackPlayer, MusicPlayer, MusicStarted, Paused};
+use super::{
+    GameplayClock, GameplayLogic, GameplayRoot, MidiTrackPlayer, MusicPlayer, MusicStarted, Paused,
+};
 
 #[derive(Component, Default, Clone)]
 pub struct CountdownOverlay;
@@ -155,7 +157,9 @@ impl Plugin for CountdownPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             Update,
-            update_countdown.run_if(in_state(AppState::Playing).and_then(|p: Res<Paused>| !p.0)),
+            update_countdown
+                .after(GameplayLogic)
+                .run_if(in_state(AppState::Playing).and_then(|p: Res<Paused>| !p.0)),
         );
     }
 }

--- a/src/gameplay/metronome_overlay.rs
+++ b/src/gameplay/metronome_overlay.rs
@@ -18,7 +18,7 @@ use crate::{
     song::{SongManifest, chart::Feel},
 };
 
-use super::{GameplayClock, Paused};
+use super::{GameplayClock, GameplayLogic, Paused};
 
 /// The metronome's tempo, decoupled from the song so it can be driven by the
 /// gameplay screens (set from the chart) or the standalone Bending Trainer (set
@@ -542,7 +542,9 @@ impl Plugin for MetronomePlugin {
             // Clicks/beat animation: gameplay (unpaused) and the Bending Trainer.
             .add_systems(
                 Update,
-                (update_metronome, click_metronome).run_if(metronome_running),
+                (update_metronome, click_metronome)
+                    .after(GameplayLogic)
+                    .run_if(metronome_running),
             )
             // Toggles + label refreshes stay responsive even while paused. The
             // buttons' click/hover ride along as inline on(...) observers (see

--- a/src/gameplay/phrase_overlay.rs
+++ b/src/gameplay/phrase_overlay.rs
@@ -8,7 +8,7 @@ use crate::{
     song::chart::{Action, Modifier, NoteEvent},
 };
 
-use super::{GameplayClock, Paused, resolve_item_time};
+use super::{GameplayClock, GameplayLogic, Paused, resolve_item_time};
 
 /// Live banner text showing the current phrase and groove from the chart.
 #[derive(Component)]
@@ -287,6 +287,7 @@ impl Plugin for PhrasePlugin {
                 Update,
                 (watch_phrase_boundaries, update_phrase, update_tab_ribbon)
                     .chain()
+                    .after(GameplayLogic)
                     .run_if(in_state(AppState::Playing).and_then(|p: Res<Paused>| !p.0)),
             );
     }

--- a/src/gameplay/song_progress_overlay.rs
+++ b/src/gameplay/song_progress_overlay.rs
@@ -54,7 +54,9 @@ use super::pause_menu::SelectedPhraseIndex;
 use super::song_waveform_material::{
     SongWaveformMaterial, SongWaveformMaterialPlugin, pack_amplitudes,
 };
-use super::{GameplayClock, GameplayRoot, LoopConfig, Paused, SongEnd, loop_range_valid};
+use super::{
+    GameplayClock, GameplayLogic, GameplayRoot, LoopConfig, Paused, SongEnd, loop_range_valid,
+};
 
 /// Every bar keeps at least this much height (as a fraction 0..1) even during
 /// silence, so the waveform reads as a continuous shape rather than gaps.
@@ -888,7 +890,9 @@ impl Plugin for SongProgressPlugin {
             .add_message::<RequestLoopRange>()
             .add_systems(
                 Update,
-                update_progress.run_if(in_state(AppState::Playing).and_then(|p: Res<Paused>| !p.0)),
+                update_progress
+                    .after(GameplayLogic)
+                    .run_if(in_state(AppState::Playing).and_then(|p: Res<Paused>| !p.0)),
             )
             .add_systems(
                 Update,


### PR DESCRIPTION
The four overlays register their systems outside plugin.rs, so they were
never ordered against the clock and could run before tick_clock.