### PR TITLE
Improve sustain

### DIFF
--- a/src/gameplay/clock.rs
+++ b/src/gameplay/clock.rs
@@ -227,6 +227,11 @@ pub(crate) fn handle_loop_boundary(
         note.missed = false;
         note.held = 0.0;
         note.sustain_scored = false;
+        // The sustain samples are what `technique_confirmed` measures a
+        // vibrato/wah rate from, so the next lap must start collecting
+        // them from scratch rather than on top of the previous lap's.
+        note.pitch_samples.clear();
+        note.amp_samples.clear();
     }
     // These notes are playable again, so `judge::score_notes`'s cursor
     // (which only ever advances past *permanently* resolved notes) can't

--- a/src/gameplay/tests.rs
+++ b/src/gameplay/tests.rs
@@ -149,8 +149,8 @@ fn loop_test_note(time: f64) -> ScheduledNote {
         held: 1.0,
         sustain_scored: true,
         modifiers: Vec::new(),
-        pitch_samples: Vec::new(),
-        amp_samples: Vec::new(),
+        pitch_samples: vec![(0.0, 440.0)],
+        amp_samples: vec![(0.0, 0.5)],
         phrase_section: 0,
         chord_pitches: Vec::new(),
         force_wait: false,
@@ -191,6 +191,10 @@ fn loop_boundary_rewinds_the_clock_and_resets_notes_in_range() {
         assert!(
             !reset.hit && !reset.missed && !reset.sustain_scored && reset.held == 0.0,
             "note {i} (in range or a LOOKAHEAD preview past it) should be reset"
+        );
+        assert!(
+            reset.pitch_samples.is_empty() && reset.amp_samples.is_empty(),
+            "note {i} must not carry the previous lap's sustain samples"
         );
     }
     assert_eq!(song_notes.cursor, 1, "cursor rewinds to the in-range note");


### PR DESCRIPTION
A looped note kept the previous lap's pitch/amplitude samples, so the
vibrato and wah rate were measured over both laps at once.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>